### PR TITLE
message: fix from_map spec

### DIFF
--- a/lib/astarte_streams/message.ex
+++ b/lib/astarte_streams/message.ex
@@ -221,7 +221,8 @@ defmodule Astarte.Streams.Message do
       iex> Message.from_map(%{})
       {:error, :invalid_message}
   """
-  @spec from_map(%{required(String.t()) => term()}) :: Message.t() | {:error, :invalid_message}
+  @spec from_map(%{required(String.t()) => term()}) ::
+          {:ok, Message.t()} | {:error, :invalid_message}
   def from_map(%{"schema" => @message_schema_version} = map) do
     with %{
            "key" => key,


### PR DESCRIPTION
It returns {:ok, message}, not just message