### PR TITLE
Make sure to terminate AMQP connections when a block terminates

### DIFF
--- a/lib/astarte_flow/blocks/container.ex
+++ b/lib/astarte_flow/blocks/container.ex
@@ -257,4 +257,13 @@ defmodule Astarte.Flow.Blocks.Container do
         state
     end
   end
+
+  @impl true
+  def terminate(_reason, %State{channel: channel, amqp_client: amqp_client} = state) do
+    if channel do
+      amqp_client.close_connection(channel.conn)
+    end
+
+    {:noreply, state}
+  end
 end

--- a/lib/astarte_flow/blocks/container/amqp_client.ex
+++ b/lib/astarte_flow/blocks/container/amqp_client.ex
@@ -39,4 +39,5 @@ defmodule Astarte.Flow.Blocks.Container.AMQPClient do
               opts :: keyword
             ) :: any
   @callback consume(channel :: Channel.t(), queue :: binary()) :: Basic.consumer_tag()
+  @callback close_connection(conn :: Connection.t()) :: :ok | {:error, any}
 end

--- a/lib/astarte_flow/blocks/container/rabbitmq_client.ex
+++ b/lib/astarte_flow/blocks/container/rabbitmq_client.ex
@@ -94,4 +94,13 @@ defmodule Astarte.Flow.Blocks.Container.RabbitMQClient do
     {:ok, consumer_tag} = Basic.consume(channel, queue)
     consumer_tag
   end
+
+  @impl true
+  def close_connection(conn) do
+    if Process.alive?(conn.pid) do
+      Connection.close(conn)
+    else
+      :ok
+    end
+  end
 end

--- a/lib/astarte_flow/blocks/device_events_producer.ex
+++ b/lib/astarte_flow/blocks/device_events_producer.ex
@@ -223,4 +223,13 @@ defmodule Astarte.Flow.Blocks.DeviceEventsProducer do
         {:noreply, Enum.reverse(messages), state}
     end
   end
+
+  @impl true
+  def terminate(_reason, %State{channel: channel, client: client} = state) do
+    if channel do
+      client.close_connection(channel.conn)
+    end
+
+    {:noreply, state}
+  end
 end

--- a/lib/astarte_flow/blocks/device_events_producer/amqp_client.ex
+++ b/lib/astarte_flow/blocks/device_events_producer/amqp_client.ex
@@ -32,4 +32,5 @@ defmodule Astarte.Flow.Blocks.DeviceEventsProducer.AMQPClient do
               opts :: keyword
             ) :: any
   @callback consume(channel :: Channel.t(), config) :: Basic.consumer_tag()
+  @callback close_connection(conn :: Connection.t()) :: :ok | {:error, any}
 end

--- a/lib/astarte_flow/blocks/device_events_producer/rabbitmq_client.ex
+++ b/lib/astarte_flow/blocks/device_events_producer/rabbitmq_client.ex
@@ -74,4 +74,13 @@ defmodule Astarte.Flow.Blocks.DeviceEventsProducer.RabbitMQClient do
     {:ok, consumer_tag} = Basic.consume(channel, config.queue)
     consumer_tag
   end
+
+  @impl true
+  def close_connection(conn) do
+    if Process.alive?(conn.pid) do
+      Connection.close(conn)
+    else
+      :ok
+    end
+  end
 end


### PR DESCRIPTION
Container and DeviceEventsProducer blocks open a connection to RabbitMQ. This
has to be closed when the blocks terminates, since it's not linked to the
process.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>