### PR TITLE
pipeline_builder: eval realm and jwt when building pairing_jwt_map

### DIFF
--- a/lib/astarte_flow/pipeline_builder.ex
+++ b/lib/astarte_flow/pipeline_builder.ex
@@ -220,7 +220,9 @@ defmodule Astarte.Flow.PipelineBuilder do
     interfaces = Map.fetch!(opts, "interfaces") |> eval(config)
 
     pairing_jwt_map =
-      Enum.into(realms, %{}, fn %{"realm" => realm, "jwt" => jwt} -> {realm, jwt} end)
+      Enum.into(realms, %{}, fn %{"realm" => realm, "jwt" => jwt} ->
+        {eval(realm, config), eval(jwt, config)}
+      end)
 
     opts = [
       pairing_url: pairing_url,


### PR DESCRIPTION
Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>