### PR TITLE
device_events_producer_test: fix FakeAMQPClient

### DIFF
--- a/test/blocks/device_events_producer_test.exs
+++ b/test/blocks/device_events_producer_test.exs
@@ -74,6 +74,10 @@ defmodule Astarte.Flow.Blocks.DeviceEventsProducerTest do
 
       send(pid, {:basic_deliver, payload, meta})
     end
+
+    def close_connection(_) do
+      :ok
+    end
   end
 
   describe "DeviceEventsProducer" do


### PR DESCRIPTION
Add close_connection function, avoid crashing during tests