### PR TITLE
random_producer: add delay_ms option

### DIFF
--- a/lib/astarte_flow/pipeline_builder.ex
+++ b/lib/astarte_flow/pipeline_builder.ex
@@ -114,8 +114,16 @@ defmodule Astarte.Flow.PipelineBuilder do
       "max" => max
     } = opts
 
+    delay_ms = Map.get(opts, "delay_ms")
+
     {RandomProducer,
-     [key: eval(key, config), type: :real, min: eval(min, config), max: eval(max, config)]}
+     [
+       key: eval(key, config),
+       type: :real,
+       min: eval(min, config),
+       max: eval(max, config),
+       delay_ms: eval(delay_ms, config)
+     ]}
   end
 
   defp setup_block("filter", opts, config) do


### PR DESCRIPTION
Allow sleeping for a certain amount of milliseconds between the production of
two samples. Add support for this setting also in the pipeline builder.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>