### PR TITLE
dynamic_virtual_device_pool: remove normalize_data

### DIFF
--- a/lib/astarte_flow/blocks/dynamic_virtual_device_pool.ex
+++ b/lib/astarte_flow/blocks/dynamic_virtual_device_pool.ex
@@ -120,9 +120,8 @@ defmodule Astarte.Flow.Blocks.DynamicVirtualDevicePool do
     with {:ok, {realm, device_id, interface, path}} <- parse_key(key),
          {:ok, pid} <- fetch_device(state, realm, device_id),
          {:ok, timestamp} <- DateTime.from_unix(timestamp_micros, :microsecond),
-         normalized_data = normalize_data(data),
          :ok <-
-           Device.send_datastream(pid, interface, path, normalized_data, timestamp: timestamp) do
+           Device.send_datastream(pid, interface, path, data, timestamp: timestamp) do
       :ok
     else
       {:error, reason} ->
@@ -232,12 +231,4 @@ defmodule Astarte.Flow.Blocks.DynamicVirtualDevicePool do
         {:error, reason}
     end
   end
-
-  defp normalize_data(data) when is_map(data) do
-    for {key, {_type, _subtype, value}} <- data, into: %{} do
-      {key, value}
-    end
-  end
-
-  defp normalize_data(data), do: data
 end


### PR DESCRIPTION
Not needed anymore.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>