### PR TITLE
Add flows persistency

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -35,5 +35,7 @@ config :astarte_flow, Astarte.FlowWeb.Endpoint,
 
 config :astarte_flow, :pipelines_storage_mod, PipelinesStorageMock
 
+config :astarte_flow, :flows_storage_mod, FlowsStorageMock
+
 # Print only warnings and errors during test
 config :logger, level: :warn

--- a/lib/astarte_flow/application.ex
+++ b/lib/astarte_flow/application.ex
@@ -29,9 +29,11 @@ defmodule Astarte.Flow.Application do
       {Registry, keys: :unique, name: Astarte.Flow.Flows.Registry},
       {Registry, keys: :duplicate, name: Astarte.Flow.Flows.RealmRegistry},
       Astarte.Flow.Pipelines.DETSStorage,
+      Astarte.Flow.Flows.DETSStorage,
       {DynamicSupervisor, strategy: :one_for_one, name: Astarte.Flow.Flows.Supervisor},
       Astarte.Flow.Blocks.DynamicVirtualDevicePool.DETSCredentialsStorage,
       {DynamicSupervisor, strategy: :one_for_one, name: Astarte.Flow.VirtualDevicesSupervisor},
+      Astarte.Flow.RestoreFlowsTask,
       Astarte.FlowWeb.Endpoint
     ]
 

--- a/lib/astarte_flow/flows/dets_storage.ex
+++ b/lib/astarte_flow/flows/dets_storage.ex
@@ -1,0 +1,99 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Flow.Flows.DETSStorage do
+  use GenServer
+
+  @behaviour Astarte.Flow.Flows.Storage
+
+  @table_name :flows
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @impl true
+  @doc "Return a list of all saved Flows in the form `{realm, %Flow{}}`"
+  @spec get_all_flows :: [{realm :: String, Astarte.Flow.Flows.Flow.t()}]
+  def get_all_flows do
+    match_pattern = {{:"$1", :_}, :"$2"}
+
+    :dets.match(@table_name, match_pattern)
+    |> Enum.map(fn [realm, flow] -> {realm, flow} end)
+  end
+
+  @impl true
+  @doc "Insert a flow into the dets table"
+  @spec insert_flow(realm :: String.t(), flow :: Astarte.Flow.Flows.Flow.t()) ::
+          :ok | {:error, reason :: term()}
+  def insert_flow(realm, flow) do
+    # This must go through the process since only the owner can write to the table
+    GenServer.call(__MODULE__, {:insert_flow, realm, flow})
+  end
+
+  @impl true
+  @doc "Delete a flow from the dets table"
+  @spec delete_flow(realm :: String.t(), name :: String.t()) ::
+          :ok | {:error, reason :: term()}
+  def delete_flow(realm, name) do
+    # This must go through the process since only the owner can write to the table
+    GenServer.call(__MODULE__, {:delete_flow, realm, name})
+  end
+
+  @impl true
+  def init(_args) do
+    file =
+      Application.get_env(:astarte_flow, :persistency_dir, "")
+      |> Path.expand()
+      |> Path.join("flows")
+      |> to_charlist()
+
+    case :dets.open_file(@table_name, type: :set, file: file) do
+      {:ok, table} ->
+        {:ok, table}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+
+  @impl true
+  def handle_call({:insert_flow, realm, flow}, _from, table) do
+    entry = {{realm, flow.name}, flow}
+
+    result =
+      case :dets.insert_new(table, entry) do
+        true ->
+          :ok
+
+        false ->
+          {:error, :already_existing_flow}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+
+    {:reply, result, table}
+  end
+
+  def handle_call({:delete_flow, realm, name}, _from, table) do
+    result = :dets.delete(table, {realm, name})
+
+    {:reply, result, table}
+  end
+end

--- a/lib/astarte_flow/flows/storage.ex
+++ b/lib/astarte_flow/flows/storage.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2019 Ispirata Srl
+# Copyright 2020 Ispirata Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,14 +16,12 @@
 # limitations under the License.
 #
 
-Mox.defmock(PairingAgentMock, for: Astarte.API.Pairing.Agent.Behaviour)
-Mox.defmock(PairingMock, for: Astarte.API.Pairing.Devices.Behaviour)
+defmodule Astarte.Flow.Flows.Storage do
+  @callback get_all_flows :: [{realm :: String.t(), Astarte.Flow.Flows.Flow.t()}]
 
-Mox.defmock(CredentialsStorageMock,
-  for: Astarte.Flow.Blocks.DynamicVirtualDevicePool.CredentialsStorage
-)
+  @callback insert_flow(realm :: String.t(), flow :: Astarte.Flow.Flows.Flow.t()) ::
+              :ok | {:error, reason :: term()}
 
-Mox.defmock(ConnectionMock, for: Astarte.Device.Connection)
-Mox.defmock(InterfaceProviderMock, for: Astarte.Device.InterfaceProvider)
-Mox.defmock(PipelinesStorageMock, for: Astarte.Flow.Pipelines.Storage)
-Mox.defmock(FlowsStorageMock, for: Astarte.Flow.Flows.Storage)
+  @callback delete_flow(realm :: String.t(), name :: String.t()) ::
+              :ok | {:error, reason :: term()}
+end

--- a/lib/astarte_flow/restore_flows_task.ex
+++ b/lib/astarte_flow/restore_flows_task.ex
@@ -1,0 +1,65 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Flow.RestoreFlowsTask do
+  use Task, restart: :transient
+
+  require Logger
+
+  alias Astarte.Flow.Flows.DETSStorage
+  alias Astarte.Flow.Flows.Flow
+  alias Astarte.Flow.Flows.Supervisor, as: FlowsSupervisor
+
+  @storage Application.get_env(:astarte_flow, :flows_storage_mod, DETSStorage)
+
+  if Mix.env() == :test do
+    # Fake task to avoid Flows from trying to be restored during tests
+    def start_link(_arg) do
+      Task.start_link(fn -> :ok end)
+    end
+  else
+    def start_link(arg) do
+      Task.start_link(__MODULE__, :run, [arg])
+    end
+  end
+
+  def run(_arg) do
+    for {realm, flow} <- @storage.get_all_flows do
+      args = [realm: realm, flow: flow]
+
+      case DynamicSupervisor.start_child(FlowsSupervisor, {Flow, args}) do
+        {:ok, _pid} ->
+          :ok
+
+        {:error, {:already_started, _pid}} ->
+          # It's ok, maybe the task was restarted after a crash
+          :ok
+
+        {:error, reason} ->
+          Logger.warn(
+            "Cannot start Flow #{inspect(flow.name)} in realm " <>
+              "#{inspect(realm)}: #{inspect(reason)}."
+          )
+
+          raise "Cannot restore flows"
+      end
+    end
+
+    :ok
+  end
+end


### PR DESCRIPTION
Save flows to a dets table and restore them during application startup

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>