### PR TITLE
Default max certificate chain length to 10

### DIFF
--- a/lib/astarte_flow/blocks/mqtt_source.ex
+++ b/lib/astarte_flow/blocks/mqtt_source.ex
@@ -182,7 +182,8 @@ defmodule Astarte.Flow.Blocks.MqttSource do
           host: host,
           port: port || 8883,
           cacertfile: :certifi.cacertfile(),
-          verify: verify
+          verify: verify,
+          depth: 10
         ]
 
         {:ok, {Tortoise.Transport.SSL, opts}}

--- a/lib/astarte_flow/config.ex
+++ b/lib/astarte_flow/config.ex
@@ -135,6 +135,7 @@ defmodule Astarte.Flow.Config do
           {:cacertfile, String.t()}
           | {:verify, :verify_peer}
           | {:server_name_indication, :disable | charlist()}
+          | {:depth, integer()}
   @type ssl_options :: :none | [ssl_option]
   @type options ::
           {:username, String.t()}
@@ -167,7 +168,8 @@ defmodule Astarte.Flow.Config do
   defp build_ssl_options do
     [
       cacertfile: default_amqp_connection_ssl_ca_file!() || CAStore.file_path(),
-      verify: :verify_peer
+      verify: :verify_peer,
+      depth: 10
     ]
     |> populate_sni()
   end


### PR DESCRIPTION
The erlang default of 1 is too strict. Increase the default value to 10
to make it coincident to OpenSSL default.