### PR TITLE
DeviceEventsProducer: stop using astarte_events

### DIFF
--- a/lib/astarte_flow/blocks/device_events_producer/rabbitmq_client.ex
+++ b/lib/astarte_flow/blocks/device_events_producer/rabbitmq_client.ex
@@ -37,7 +37,7 @@ defmodule Astarte.Flow.Blocks.DeviceEventsProducer.RabbitMQClient do
     routing_key = Keyword.fetch!(opts, :routing_key)
     queue = Keyword.get(opts, :queue, "")
     connection = Keyword.get(opts, :connection, [])
-    exchange = Keyword.get(opts, :exchange, "astarte_events")
+    exchange = Keyword.fetch!(opts, :exchange)
     prefetch_count = Keyword.get(opts, :prefetch_count, 100)
 
     config = %{

--- a/lib/astarte_flow/pipeline_builder.ex
+++ b/lib/astarte_flow/pipeline_builder.ex
@@ -57,14 +57,22 @@ defmodule Astarte.Flow.PipelineBuilder do
 
   defp setup_block("astarte_devices_source", opts, config) do
     %{
-      "realm" => realm
+      "realm" => realm,
+      "amqp_exchange" => amqp_exchange
     } = opts
 
+    amqp_routing_key = Map.get(opts, "amqp_routing_key", "")
     target_devices = Map.get(opts, "target_devices")
+
+    # TODO: we should go for a proper validation system
+    unless amqp_exchange =~ ~r"^astarte_events_#{realm}_[a-zA-Z0-9_\.\:]+$" do
+      raise "exchange name not allowed"
+    end
 
     {DeviceEventsProducer,
      [
-       routing_key: "trigger_engine",
+       exchange: amqp_exchange,
+       routing_key: amqp_routing_key,
        realm: eval(realm, config),
        target_devices: eval(target_devices, config),
        connection: Config.default_amqp_connection!(),


### PR DESCRIPTION
astarte_events was meant to be used from trigger engine, add exchange option in order to allow consuming from any other amqp exchange.