### PR TITLE
endpoint: move CORSPlug before HealthPlug and MetricsPlug

### DIFF
--- a/lib/astarte_flow_web/endpoint.ex
+++ b/lib/astarte_flow_web/endpoint.ex
@@ -40,6 +40,7 @@ defmodule Astarte.FlowWeb.Endpoint do
   end
 
   plug Plug.RequestId
+  plug CORSPlug
   plug Astarte.FlowWeb.HealthPlug
   plug Astarte.FlowWeb.MetricsPlug
   plug PlugLoggerWithMeta
@@ -61,6 +62,5 @@ defmodule Astarte.FlowWeb.Endpoint do
     key: "_astarte_flow_key",
     signing_salt: "PNSxHV7l"
 
-  plug CORSPlug
   plug Astarte.FlowWeb.Router
 end


### PR DESCRIPTION
Allow the Dashboard to perform health requests

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>