### PR TITLE
Render blocks as object in index

### DIFF
--- a/lib/astarte_flow_web/views/block_view.ex
+++ b/lib/astarte_flow_web/views/block_view.ex
@@ -22,7 +22,7 @@ defmodule Astarte.FlowWeb.BlockView do
   alias Astarte.FlowWeb.BlockView
 
   def render("index.json", %{blocks: blocks}) do
-    %{data: render_many(blocks, BlockView, "block_name.json")}
+    %{data: render_many(blocks, BlockView, "block.json")}
   end
 
   def render("show.json", %{block: block}) do

--- a/test/astarte_flow_web/controllers/block_controller_test.exs
+++ b/test/astarte_flow_web/controllers/block_controller_test.exs
@@ -76,7 +76,10 @@ defmodule Astarte.FlowWeb.BlockControllerTest do
       conn = get(conn, Routes.block_path(conn, :index, @realm))
       blocks = json_response(conn, 200)["data"]
 
-      assert Enum.member?(blocks, @name)
+      user_block = Enum.find(blocks, &(&1["name"] == @name))
+      assert user_block["source"] == @source
+      assert user_block["type"] == @block_type
+      assert user_block["schema"] == @schema
     end
   end
 


### PR DESCRIPTION
Allow the API users to access all block details when listing them

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>