### PR TITLE
Update astarte_device, deprecating /v1 suffix in pairing_url

### DIFF
--- a/lib/astarte_flow/blocks/dynamic_virtual_device_pool.ex
+++ b/lib/astarte_flow/blocks/dynamic_virtual_device_pool.ex
@@ -31,6 +31,7 @@ defmodule Astarte.Flow.Blocks.DynamicVirtualDevicePool do
 
   alias Astarte.API.Pairing
   alias Astarte.Device
+  alias Astarte.Flow.Compat
   alias Astarte.Flow.Message
   alias Astarte.Flow.Blocks.DynamicVirtualDevicePool.DETSCredentialsStorage
   alias Astarte.Flow.VirtualDevicesSupervisor
@@ -52,7 +53,10 @@ defmodule Astarte.Flow.Blocks.DynamicVirtualDevicePool do
 
   ## Options
 
-    * `:pairing_url` (required) - URL of the Astarte Pairing API instance the devices will connect to, up to (and including) `/v1`.
+    * `:pairing_url` (required) - base URL of the Astarte Pairing API instance the devices will
+      connect to, e.g. `https://astarte.api.example.com/pairing` or `http://localhost:4003` for
+      a local installation. URL containing the API version suffix (i.e. `/v1`) are *deprecated*
+      and will be removed in a future release.
     * `:pairing_jwt_map` (required) - A map in the form `%{realm_name => jwt}` where jwt must be a JWT with the authorizations needed
       to register a device in that realm.
     * `:interface_provider` (required) - The `interface_provider` that will be used by the spawned devices.
@@ -77,7 +81,10 @@ defmodule Astarte.Flow.Blocks.DynamicVirtualDevicePool do
 
   @impl true
   def init(opts) do
-    pairing_url = Keyword.fetch!(opts, :pairing_url)
+    pairing_url =
+      Keyword.fetch!(opts, :pairing_url)
+      |> Compat.normalize_device_pairing_url()
+
     pairing_jwt_map = Keyword.fetch!(opts, :pairing_jwt_map)
     interface_provider = Keyword.fetch!(opts, :interface_provider)
     ignore_ssl_errors = Keyword.get(opts, :ignore_ssl_errors, false)

--- a/lib/astarte_flow/blocks/virtual_device_pool.ex
+++ b/lib/astarte_flow/blocks/virtual_device_pool.ex
@@ -29,6 +29,7 @@ defmodule Astarte.Flow.Blocks.VirtualDevicePool do
   require Logger
 
   alias Astarte.Device
+  alias Astarte.Flow.Compat
   alias Astarte.Flow.Message
   alias Astarte.Flow.VirtualDevicesSupervisor
 
@@ -37,7 +38,10 @@ defmodule Astarte.Flow.Blocks.VirtualDevicePool do
 
   ## Options
 
-    * `:pairing_url` (required) - URL of the Astarte Pairing API instance the devices will connect to, up to (and including) `/v1`.
+    * `:pairing_url` (required) - base URL of the Astarte Pairing API instance the devices will
+      connect to, e.g. `https://astarte.api.example.com/pairing` or `http://localhost:4003` for a
+      local installation. URL containing the API version suffix (i.e. `/v1`) are *deprecated* and
+      will be removed in a future release.
     * `:devices` (required) - A list of supported devices, each represented by its `device_options` (see "Device options" below).
     * `:ignore_ssl_errors` - A boolean to indicate wether devices have to ignore SSL errors when connecting to the broker. Defaults to `false`.
 
@@ -70,7 +74,10 @@ defmodule Astarte.Flow.Blocks.VirtualDevicePool do
 
   @impl true
   def init(opts) do
-    pairing_url = Keyword.fetch!(opts, :pairing_url)
+    pairing_url =
+      Keyword.fetch!(opts, :pairing_url)
+      |> Compat.normalize_device_pairing_url()
+
     devices = Keyword.fetch!(opts, :devices)
     ignore_ssl_errors = Keyword.get(opts, :ignore_ssl_errors, false)
 

--- a/lib/astarte_flow/compat.ex
+++ b/lib/astarte_flow/compat.ex
@@ -1,0 +1,49 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Flow.Compat do
+  @moduledoc """
+  This module provides compatibility helpers to support multiple formats of configuration
+  during the deprecation period.
+  """
+
+  require Logger
+
+  # TODO: remove this when we remove the trailing `/v1` in `pairing_url` from all existing
+  # pipelines/flows
+  @doc """
+  Removes the trailing `/v1` from a `pairing_url` if it finds one, printing a warning.
+  """
+  def normalize_device_pairing_url(pairing_url) when is_binary(pairing_url) do
+    stripped_url = String.trim_trailing(pairing_url, "/")
+
+    if String.ends_with?(stripped_url, "/v1") do
+      _ =
+        Logger.warn(
+          "Found trailing /v1 in pairing_url: #{pairing_url}. " <>
+            "The /v1 suffix is deprecated and will stop working in a future release. " <>
+            "Please update your pipeline or flow configuration removing the /v1 suffix.",
+          tag: "deprecated_pairing_url"
+        )
+
+      String.replace_trailing(stripped_url, "/v1", "")
+    else
+      pairing_url
+    end
+  end
+end

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "amqp": {:hex, :amqp, "1.4.0", "4172595d467b9360850a8eca254c5946af9970684d335d555a9f3410a0e43995", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "333ace582c4eacc65ebb8378358e0b8bd46474556f2855c417d4257bbf425dbf"},
   "amqp_client": {:hex, :amqp_client, "3.8.2", "b50ac381c3c016a697d6ab8f08367043a08358cfeb8ee97832ccc7d101e59cef", [:make, :rebar3], [{:rabbit_common, "3.8.2", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "f453386e02a7ae77e0aa88bf4cf071aa31cce54e1b8511ca805961b0d83f164e"},
   "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "d0491f28ca5060f4b5e2a8b6d1549dc0afaf7f91", []},
-  "astarte_device": {:git, "https://github.com/astarte-platform/astarte-device-sdk-elixir.git", "2ef1576eeab19e90ac73e9d69459697899c889e7", []},
+  "astarte_device": {:git, "https://github.com/astarte-platform/astarte-device-sdk-elixir.git", "4d1c388b8c9d4f0b55a60a1fb99a02008fa2999e", []},
   "castore": {:hex, :castore, "0.1.5", "591c763a637af2cc468a72f006878584bc6c306f8d111ef8ba1d4c10e0684010", [:mix], [], "hexpm", "6db356b2bc6cc22561e051ff545c20ad064af57647e436650aa24d7d06cd941a"},
   "certifi": {:hex, :certifi, "2.5.2", "b7cfeae9d2ed395695dd8201c57a2d019c0c43ecaf8b8bcb9320b40d6662f340", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "3b3b5f36493004ac3455966991eaf6e768ce9884693d9968055aeeeb1e575040"},
   "coerce": {:hex, :coerce, "1.0.1", "211c27386315dc2894ac11bc1f413a0e38505d808153367bd5c6e75a4003d096", [:mix], [], "hexpm", "b44a691700f7a1a15b4b7e2ff1fa30bebd669929ac8aa43cffe9e2f8bf051cf1"},

--- a/test/compat_test.exs
+++ b/test/compat_test.exs
@@ -1,0 +1,57 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2020 Ispirata Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Flow.CompatTest do
+  use ExUnit.Case
+  alias Astarte.Flow.Compat
+
+  import ExUnit.CaptureLog
+
+  @warning_pattern "The /v1 suffix is deprecated"
+
+  describe "normalize_device_pairing_url/1" do
+    test "returns the same URL for local URL if it doesn't have a trailing `v1`" do
+      url = "http://localhost:4003"
+
+      assert Compat.normalize_device_pairing_url(url) == url
+    end
+
+    test "returns the same URL for remote URL if it doesn't have a trailing `v1`" do
+      url = "https://api.astarte.example.com/pairing/"
+
+      assert Compat.normalize_device_pairing_url(url) == url
+    end
+
+    test "returns a normalized URL and prints warning for local URL if it has a trailing `v1`" do
+      url = "http://localhost:4003/v1"
+
+      assert capture_log(fn ->
+               assert Compat.normalize_device_pairing_url(url) == "http://localhost:4003"
+             end) =~ @warning_pattern
+    end
+
+    test "returns a normalized URL and prints warning for remote URL if it has a trailing `v1`" do
+      url = "https://api.astarte.example.com/pairing/v1/"
+
+      assert capture_log(fn ->
+               assert Compat.normalize_device_pairing_url(url) ==
+                        "https://api.astarte.example.com/pairing"
+             end) =~ @warning_pattern
+    end
+  end
+end


### PR DESCRIPTION
Print a warning to make users adopt the new convention before removing the
compatibility layer

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>