### PR TITLE
container: don't assume we have an outbound queue

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -39,7 +39,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/setup-elixir@v1.5.0
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}
@@ -67,7 +67,7 @@ jobs:
       with:
         path: _build
         key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ github.sha }}
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/setup-elixir@v1.5.0
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}

--- a/lib/astarte_flow/blocks/container.ex
+++ b/lib/astarte_flow/blocks/container.ex
@@ -214,7 +214,7 @@ defmodule Astarte.Flow.Blocks.Container do
       image: image,
       config: config,
       inbound_routing_key: exchange_routing_key,
-      outbound_queues: [queue]
+      outbound_queues: outbound_queues
     } = state
 
     container_block = %ContainerBlock{
@@ -222,7 +222,7 @@ defmodule Astarte.Flow.Blocks.Container do
       image: image,
       config: config,
       exchange_routing_key: exchange_routing_key,
-      queue: queue,
+      queue: List.first(outbound_queues),
       # TODO: these are random values since we are currently forced to provide them to the struct
       cpu_limit: "1",
       memory_limit: "2048M",


### PR DESCRIPTION
If the container is a producer, then outbound queues is an empty list

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>