### PR TITLE
doc: add documentation for additional blocks

### DIFF
--- a/guides/blocks/0112-lua_map.md
+++ b/guides/blocks/0112-lua_map.md
@@ -1,0 +1,57 @@
+# lua_map
+
+* type: producer_consumer
+* accepted input: any kind of message
+* output: transformed input message
+
+This is a producer and consumer block that takes an incoming message and it transforms it using the
+given Lua script.
+
+This block supports [Lua 5.2](https://www.lua.org/manual/5.2/) scripts (
+[luerl scripting engine](https://github.com/rvirding/luerl) is used under the hood). The incoming
+message will be provided to the script as `message`.
+
+This block name is not related to the map abstract data type and it should be not confused with it,
+instead it is related to the function (our script) application to a sequence of items (the
+messages).
+
+# Properties
+
+* `script`: Lua script. (required, string)
+* `config`: Lua script configuration object. (optional, object)
+
+## `script`
+
+A Lua [Lua 5.2](https://www.lua.org/manual/5.2/) script. The most simple script is
+`"return message;"` which returns an unmodified message.
+
+See also [luerl documentation](https://github.com/rvirding/luerl/wiki).
+
+## `config`
+
+Any object. Config parameter is meant as a method to provide parameters to the Lua script, without
+hard-coding them. It can be accessed using `config`.
+
+# Output message
+
+An input message transformation which depends on the script implementation.
+Missing message attributes are taken from the input message, therefore some fields are kept
+unchanged.
+
+# Examples
+
+The following example uses `lua_map` block for Fahrenheit to Celsius degrees conversion. A key
+prefix is provided through `config` object and prepended to the string `"/celsius"`.
+All other existing message attributes are taken as-is from the input message.
+
+```
+[...]
+| lua_map
+  .script("""
+    new_message.key = config.prefix .. "/celsius";
+    new_message.data = (message.data - 32) / 1.8;
+    return new_message;
+  """)
+  .config(${config})
+[...]
+```

--- a/guides/blocks/0117-sort.md
+++ b/guides/blocks/0117-sort.md
@@ -1,0 +1,43 @@
+# sort
+
+* type: producer_consumer
+* accepted input: any kind of message
+* output: any kind of message (order is changed)
+
+This block is a stateful realtime block, which reorders an out of order sequence of messages, and
+optionally removes any duplicate message.
+
+# Properties
+
+* `window_size_ms`: Window size in milliseconds. (required, integer)
+* `deduplicate`: Duplicated messages are discarded when true. (optional, boolean, default: false)
+
+## `window_size_ms`
+
+The amount of time a message is kept for reorder and deduplicate operations.
+This block always introduces a lag of `window_size_ms` milliseconds, so the window size should be
+carefully choosen.
+
+## `deduplicate`
+
+When this option is `true` messages are deduplicated. Two messages are duplicate when they have
+same timestamp and value (any other message attribute is ignored) and they are both inside the
+same sliding window.
+
+# Output message
+
+No transformation is performed on messages, however some messages taken from input are discarded or
+reordered.
+
+# Examples
+
+The following example uses sort to deduplicate messages that might be duplicated due to source or
+transport peculiarities:
+
+```
+[...]
+| sort
+  .window_size_ms(2000)
+  .deduplicate(true)
+[...]
+```

--- a/guides/blocks/0118-json_path_map.md
+++ b/guides/blocks/0118-json_path_map.md
@@ -1,0 +1,46 @@
+# json_path_map
+
+**This block API will likely change in future versions.**
+
+* type: producer_consumer
+* accepted input: binary messages (in JSON format, with "application/json" subtype)
+* output: message with the structure described by the template
+
+Transforms the incoming JSON message using the configured JSON template which makes use of
+JSONPath to extract data from the incoming message.
+
+# Properties
+
+* `template`: JSONPath template. (required, string)
+
+## `template`
+
+output message template. It must be a valid JSON that makes use of JSONPath.
+
+# Output message
+
+If the template rendering succeeds, `json_path_map` produces a message as described by `template`.
+
+# Examples
+
+Extracts data from JSON using JSONPath expressions, and it populates a map having keys `a`, `b`,
+`c`:
+
+```
+[...]
+| json_path_template
+  .template("""
+    {
+      "data": {
+        "a": "{{$.data.data[0].values[?(@.name == \"a\")].value}}",
+        "b": "{{$.data.data[0].values[?(@.name == \"b\")].value}}",
+        "c": "{{$.data.data[0].values[?(@.name == \"c\")].value}}"
+      },
+      "type": {
+        "a": "real",
+        "b": "real",
+        "c": "real"
+      }
+    }
+[...]
+```

--- a/guides/blocks/0119-split_map.md
+++ b/guides/blocks/0119-split_map.md
@@ -1,0 +1,94 @@
+# split_map
+
+**This block API will likely change in future versions, see also
+[GH issue #108](https://github.com/astarte-platform/astarte_flow/issues/108).**
+
+* type: producer_consumer
+* accepted input: a map message having `n` keys
+* output: `n` messages with different message keys
+
+This block breaks a map message into several messages, one for each map item.
+
+# Properties
+
+* `key_action`: Input map and output message key handling policy. (optional, string, default:
+   `"replace"`)
+* `delimiter`: Key delimiter string. (optional, string, default: `""`)
+* `fallback_action`: Unsplittable messages policy. (optional, string, default: `"pass_through"`)
+* `fallback_key`: Message key used when `"replace_key"` `"fallback_action"` is used. (optional, string)
+
+## `key_action`
+
+Output message key building policy, it can be either one of the following:
+* `"none"`: output message key is input message key (no changes)
+* `"replace"`: output message key is replaced with keys used in input message map.
+* `"append"`: input message map key is appended to the input message key
+* `"prepend"`: input message map key is prepended to the input message key
+
+Let's assume the input message looks like the following:
+```
+{
+  key: "inputkey"
+  data: {
+    one: 1,
+    truthy: true,
+    hello: "world"
+  }
+}
+```
+
+When using `"none"` the following 3 messages will be produced:
+* `{ key: "inputkey", data: 1, type: integer }`
+* `{ key: "inputkey", data: true, type: boolean }`
+* `{ key: "inputkey", data: "world", type: string }`
+
+When using `"replace"` the following 3 messages will be produced:
+* `{ key: "one", data: 1, type: integer }`
+* `{ key: "truthy", data: true, type: boolean }`
+* `{ key: "hello", data: "world", type: string }`
+
+When using `"append"` the following 3 messages will be produced:
+* `{ key: "inputkeyone", data: 1, type: integer }`
+* `{ key: "inputkeytruthy", data: true, type: boolean }`
+* `{ key: "inputkeyhello", data: "world", type: string }`
+
+When using `"prepend"` the following 3 messages will be produced:
+* `{ key: "oneinputkey", data: 1, type: integer }`
+* `{ key: "truthyinputkey", data: true, type: boolean }`
+* `{ key: "helloinputkey", data: "world", type: string }`
+
+## `delimiter`
+
+String delimiter that is used when `key_action` is set to `"append"` or `"prepend"`, which is used
+to separate the input message key and the appended/prepended map key.
+
+## `fallback_action`
+
+Fallback action is used when input message has no map type.
+
+The following fallback actions are available:
+* `"discard"`: input message is always discarded when it cannot be splitted
+* `"replace_key"`: input message is kept but key is replaced with specified replace key
+* `"pass_through": input message is passed through without any change
+
+## `fallback_key`
+
+`fallback_key` is used when `"replace_key"` `"fallback_action"` is used.
+
+# Output message
+
+For each message having a map with `n` keys, `n` messages are produced.
+
+# Examples
+
+The following example uses `map_split` to split messages having type map into messages that make
+use of base or array types, the output message key is built by appending the key of each map item
+to the input message key.
+
+```
+[...]
+| map_split
+  .key_action("append")
+  .delimiter("/")
+[...]
+```


### PR DESCRIPTION
Add documentation for following blocks:
* `lua_map`
* `sort`
* `json_path_map`
* `split_map`