### PR TITLE
docs-workflow: working-directory is not needed in setup-elixir

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -31,7 +31,6 @@ jobs:
         ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
         path: docs
     - uses: actions/setup-elixir@v1.5.0
-      working-directory: ./astarte_flow
       with:
         otp-version: 21.3
         elixir-version: 1.8.2


### PR DESCRIPTION
Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>