### PR TITLE
doc: add missing ":"

### DIFF
--- a/guides/blocks/astarte_devices_source.md
+++ b/guides/blocks/astarte_devices_source.md
@@ -73,7 +73,7 @@ message with key
   type is deduced using an heuristic approach. This must be handled with care especially with
   numeric types, where there can be some instances where a `double` interface generates messages
   with `integer` type.
-* `timestamp` contains the timestamp (in microseconds) of the event. If the source interface
+* `timestamp`: contains the timestamp (in microseconds) of the event. If the source interface
   supports `explicit_timestamp`, the timestamp is the one explicitly sent from the device, otherwise
   it's the reception timestamp.
 

--- a/guides/blocks/http_source.md
+++ b/guides/blocks/http_source.md
@@ -43,7 +43,7 @@ If the request succeeds, `http_source` produces a message containing these field
   to `"application/octet-stream"` if it's not found.
 * `metadata`: contains the `"base_url"` key with `base_url` as value. Moreover, it contains all the
   HTTP headers contained in the response with their keys prefixed with `"Astarte.Flow.HttpSource."`.
-* `timestamp` contains the timestamp (in microseconds) the response was received.
+* `timestamp`: contains the timestamp (in microseconds) the response was received.
 
 If the request can't be performed or an error status (`>= 400`) is returned, no message is
 produced.

--- a/guides/blocks/mqtt_source.md
+++ b/guides/blocks/mqtt_source.md
@@ -57,7 +57,7 @@ A MIME type that will be put as [`subtype`](0002-flow-messages.html#subtype) in 
 * `subtype`: is always `"application/octet-stream"` but can be configured with the `subtype` option
 * `metadata`: contains the `Astarte.Flow.Blocks.MqttSource.broker_url` key with the broker url as
    value.
-* `timestamp` contains the timestamp (in microseconds) the response was received.
+* `timestamp`: contains the timestamp (in microseconds) the response was received.
 
 # Examples
 

--- a/guides/blocks/random_source.md
+++ b/guides/blocks/random_source.md
@@ -53,7 +53,7 @@ The delay between generated messages in milliseconds. For example use `5000` for
 * `key`: contains the `key` specified as parameter.
 * `data`: contains the generated value.
 * `type`: the `type` specified as parameter.
-* `timestamp` contains the timestamp (in microseconds) in which the message was generated.
+* `timestamp`: contains the timestamp (in microseconds) in which the message was generated.
 
 # Examples
 

--- a/guides/core_concepts/0002-flow-messages.md
+++ b/guides/core_concepts/0002-flow-messages.md
@@ -52,7 +52,7 @@ Keys can be any non empty string, Astarte Flow will take care of consistent shar
 
 Each message has a timestamp with microsecond precision, timestamps are generally related to the event
 that generated the message. For instance when the message represents a sensor measurement,
-timestamp will be likely the measurement timestamp (since
+timestamp will likely be the measurement timestamp (since
 [UTC Epoch](https://en.wikipedia.org/wiki/Unix_time)).
 
 ## Subtype


### PR DESCRIPTION
`timestamp` contains the timestamp -> `timestamp`: contains the timestamp.