### PR TITLE
mqtt_sink: fix missing handler and handle_info

### DIFF
--- a/lib/astarte_flow/blocks/mqtt_sink.ex
+++ b/lib/astarte_flow/blocks/mqtt_sink.ex
@@ -107,6 +107,12 @@ defmodule Astarte.Flow.Blocks.MqttSink do
     {:noreply, [], state}
   end
 
+  @impl true
+  def handle_info({{Tortoise, _}, _ref, _response}, state) do
+    # TODO: These are sent when QoS is 1 or 2, ignore these for now
+    {:noreply, [], state}
+  end
+
   defp fetch_qos(opts) do
     case Keyword.fetch(opts, :qos) do
       :error ->
@@ -128,7 +134,8 @@ defmodule Astarte.Flow.Blocks.MqttSink do
       base_opts = [
         client_id: client_id,
         broker_url: broker_url,
-        server: server
+        server: server,
+        handler: {Tortoise.Handler.Logger, []}
       ]
 
       additional_opts =


### PR DESCRIPTION
Handler is required, we don't plan to receive messages so we just use the
default Tortoise handler for now. Also add handle_info to catch confirmation
messages for QoS 1 and QoS 2 publish.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>