### PR TITLE
lua_mapper: fix: Float.round fails on integer

### DIFF
--- a/lib/astarte_flow/blocks/lua_mapper.ex
+++ b/lib/astarte_flow/blocks/lua_mapper.ex
@@ -222,7 +222,7 @@ defmodule Astarte.Flow.Blocks.LuaMapper do
     %Message{msg | data: cast_data(data, type)}
   end
 
-  defp cast_data(data, :integer) do
+  defp cast_data(data, :integer) when is_float(data) do
     data
     |> Float.round()
     |> Kernel.trunc()


### PR DESCRIPTION
Use Float.round only when data is a float but expected type is integer,
otherwise no rounding is required.