### PR TITLE
modbus_tcp_source: fix: floating point numbers are called real

### DIFF
--- a/lib/astarte_flow/blocks/modbus_tcp_source.ex
+++ b/lib/astarte_flow/blocks/modbus_tcp_source.ex
@@ -247,8 +247,8 @@ defmodule Astarte.Flow.Blocks.ModbusTCPSource do
     case format do
       :int16 -> :integer
       :uint16 -> :integer
-      :float32be -> :float
-      :float32le -> :float
+      :float32be -> :real
+      :float32le -> :real
       :boolean -> :boolean
     end
   end


### PR DESCRIPTION
floating point numbers type is called real and not float.