### PR TITLE
default_blocks: fix external_resource path

### DIFF
--- a/lib/astarte_flow/blocks/default_blocks.ex
+++ b/lib/astarte_flow/blocks/default_blocks.ex
@@ -20,7 +20,7 @@ defmodule Astarte.Flow.Blocks.DefaultBlocks do
   alias Astarte.Flow.Blocks.Block
 
   # Recompile when the blocks directory changes
-  @external_resource Path.expand("priv/blocks", __DIR__)
+  @external_resource "priv/blocks"
 
   Module.register_attribute(__MODULE__, :default_blocks, accumulate: true)
 


### PR DESCRIPTION
Flow wasn't recompiled when JSON schema files were changed. Don't use
Path.expand since that will make the directory relative w.r.t. the
default_blocks.ex file, while just leaving the bare path will make it relative
to the mix.exs root (which is what we want).

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>