### PR TITLE
flow: call K8s.try_delete_flow only if there are container blocks

### DIFF
--- a/lib/astarte_flow/flows/flow.ex
+++ b/lib/astarte_flow/flows/flow.ex
@@ -339,6 +339,8 @@ defmodule Astarte.Flow.Flows.Flow do
 
   @impl true
   def terminate(_reason, state) do
-    K8s.try_delete_flow(state.flow.name)
+    if state.container_block_pids != [] do
+      K8s.try_delete_flow(state.flow.name)
+    end
   end
 end


### PR DESCRIPTION
Avoid printing an error when a flow is deleted in a deployment that is not K8s
based, even if it doesn't need to stop anything on the K8s side.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>