### PR TITLE
Fix handling of `ignore_ssl_errors` field in http_sink block

### DIFF
--- a/priv/blocks/http_sink.json
+++ b/priv/blocks/http_sink.json
@@ -1,22 +1,26 @@
 {
   "name": "http_sink",
-
   "beam_module": "Elixir.Astarte.Flow.Blocks.HttpSink",
   "type": "consumer",
-
   "schema": {
     "$id": "https://astarte-platform.org/specs/astarte_flow/blocks/http_sink.json",
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "HttpSinkOptions",
     "type": "object",
-
     "additionalProperties": false,
-    "required": ["url"],
-
+    "required": [
+      "url"
+    ],
     "properties": {
       "url": {
         "type": "string",
         "description": "Target URL."
+      },
+      "ignore_ssl_errors": {
+        "default": false,
+        "description": "If true, accept invalid certificates (e.g. self-signed) when using SSL.",
+        "title": "Ignore SSL errors",
+        "type": "boolean"
       }
     }
   }


### PR DESCRIPTION
Do not fail pipeline instantiation when `ignore_ssl_errors` is added to an http_sink block