### PR TITLE
Bump the api version of Flows to v1alpha2

### DIFF
--- a/lib/astarte_flow/k8s.ex
+++ b/lib/astarte_flow/k8s.ex
@@ -23,7 +23,7 @@ defmodule Astarte.Flow.K8s do
   alias K8s.Conn
   alias Astarte.Flow.Config
 
-  @api_version "api.astarte-platform.org/v1alpha1"
+  @api_version "api.astarte-platform.org/v1alpha2"
   @flow_kind "Flow"
 
   defmodule ContainerBlock do


### PR DESCRIPTION
Starting from the Astarte Operator v24.5, the v1alpha1 api version is removed. Therefore, to guarantee flows to be instantiated, bump the api version.